### PR TITLE
[FE-19] 버튼 컴포넌트 수정

### DIFF
--- a/src/components/atoms/Button/StyledButton.tsx
+++ b/src/components/atoms/Button/StyledButton.tsx
@@ -1,0 +1,95 @@
+import { Pressable, StyleSheet, Dimensions } from 'react-native';
+import Colors from '@/styles/colors';
+import TextTitle from '@/components/atoms/Text/TextTitle';
+
+type StyledButtonProps = {
+  // eslint-disable-next-line react/require-default-props
+  type?: 'full' | 'medium' | 'small' | 'outlined';
+  content: string;
+  active: boolean;
+  onPress: () => void;
+};
+
+export default function StyledButton({
+  type,
+  content,
+  active,
+  onPress,
+}: StyledButtonProps) {
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        pressed && styles.pressed,
+        styles.container,
+        active ? styles.active : styles.inactive,
+        type && styles[type],
+      ]}
+      onPress={onPress}
+    >
+      <TextTitle
+        style={[
+          styles.basic,
+          type === 'outlined' && styles.outlinedText,
+          type === 'small' && styles.smallText,
+        ]}
+      >
+        {content}
+      </TextTitle>
+    </Pressable>
+  );
+}
+
+const screenWidth = Dimensions.get('window').width;
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    borderRadius: 5,
+    width: 345,
+    height: 42,
+  },
+  basic: {
+    fontFamily: 'Montserrat-SemiBold',
+    fontSize: 16,
+    lineHeight: 18,
+    textAlign: 'center',
+    color: '#ffffff',
+  },
+  active: {
+    backgroundColor: Colors.main,
+  },
+  inactive: {
+    backgroundColor: Colors.footerText,
+  },
+  pressed: {
+    opacity: 0.5,
+  },
+  full: {
+    width: screenWidth,
+    height: 50,
+    borderRadius: 0,
+  },
+  medium: {
+    width: 285,
+    height: 50,
+  },
+  small: {
+    width: 88,
+    backgroundColor: Colors.lineGray,
+  },
+  smallText: {
+    fontFamily: 'Montserrat-Medium',
+    fontSize: 12,
+    lineHeight: 15,
+    color: '#000000',
+    textAlign: 'center',
+  },
+  outlined: {
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: Colors.main,
+  },
+  outlinedText: {
+    color: Colors.main,
+  },
+});

--- a/src/screens/ContentScreen.tsx
+++ b/src/screens/ContentScreen.tsx
@@ -5,6 +5,7 @@ import ContentAmi from '@components/organisms/Section/ContentAmi';
 import ContentProgram from '@components/organisms/Section/ContentProgram';
 import ContentBannerCarousel from '@components/molecules/Banner/ContentBannerCarousel';
 import ContentPayment from '@components/molecules/Section/ContentPayment';
+import StyledButton from '@/components/atoms/Button/StyledButton';
 
 export default function ContentScreen() {
   return (
@@ -16,6 +17,8 @@ export default function ContentScreen() {
         <ContentAmi />
         <ContentProgram />
         <ContentPayment />
+        {/* 테스트용 코드 */}
+        <StyledButton type='full' content='Apply' active onPress={() => {}} />
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
- StlyedButton 컴포넌트에서 type을 prop으로 받고 타입 별 스타일을 따로 지정하는 방식으로 수정했습니다
- type을 적지 않으면 기본으로 아래 스타일 버튼을 띄우도록 했습니다
<img width="280" alt="스크린샷 2023-12-08 오후 3 57 20" src="https://github.com/TRIP-AMI/tripami_client/assets/105159293/67d04d08-aba2-4d7a-912d-9d72b1919bd2">
